### PR TITLE
Fixed typo

### DIFF
--- a/object-checker.js
+++ b/object-checker.js
@@ -139,7 +139,7 @@ exports.createErrorMessage = function(e, messageTemplate) {
 };
 
 exports.errorHandler = function(err, req, res, next) {
-  var message = exports.createErrorMessage(err, exports.template);
+  var message = exports.createErrorMessage(err, exports.messageTemplate);
   res.send(message);
 };
 


### PR DESCRIPTION
`exports.template` does not exist in the context. It's most definitely meant to be `exports.messageTemplate`